### PR TITLE
feat(chat): implement Pyodide strategy and add UI enhancements

### DIFF
--- a/public/main.py
+++ b/public/main.py
@@ -1,39 +1,67 @@
+import json
 import pandas as pd
-import streamlit as st
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.neighbors import NearestNeighbors
 
-data = pd.read_csv('dataset.csv', encoding='latin1')
-data.fillna('', inplace=True)  # Reemplaza los valores NaN con cadenas vacías
-preguntas = data["pregunta"].tolist()
-respuestas = data["respuesta"].tolist()
+# Global variables to store the model and data once initialized
+vectorizer = None
+model = None
+answers = None
 
-vectorizer = TfidfVectorizer()
-preguntas_vectorizadas = vectorizer.fit_transform(preguntas)
-respuestas_vectorizadas = vectorizer.transform(respuestas)
 
-modelo = NearestNeighbors(n_neighbors=1)
-modelo.fit(preguntas_vectorizadas)
+def initialize_model(json_data_string):
+    """
+    Initializes the vectorizer and NearestNeighbors model
+    with the knowledge base data.
+    This function is called once from JavaScript.
+    """
+    global vectorizer, model, answers
 
-def obtener_respuesta(pregunta):
-    pregunta_vectorizada = vectorizer.transform([pregunta])
-    indice_mas_cercano = modelo.kneighbors(pregunta_vectorizada)[1][0][0]
-    return respuestas[indice_mas_cercano]
+    print("Python: Initializing model with received data...")
 
-st.title("Chatbot-UPIICSA")
-st.write("Si no sientes que la respuesta del bot tenga sentido, hazla llegar a algún alumnx consejerx o mándala al formulario https://forms.gle/YmpQqeLifvMDRymDA para mejorar el bot.")
+    # Load data from the JSON string passed by JavaScript
+    data = json.loads(json_data_string)
+    df = pd.DataFrame(data)
 
-pregunta = st.text_input("Pregunta:")
-if st.button("Enviar"):
-    respuesta = obtener_respuesta(pregunta)
-    if respuesta:
-        st.markdown(f'**Respuesta:**\n\n{respuesta}')
-    else:
-        st.markdown('Lo siento, esta pregunta aún no soy capaz de responderla, hazla llegar a algún alumnx consejerx o mándala al forms https://forms.gle/YmpQqeLifvMDRymDA')
+    # Ensure there are no null values
+    df.fillna("", inplace=True)
 
-for _ in range(10):  # Añadir espacios en blanco
-    st.write('')
+    # Extract questions and answers
+    questions = df["question"].tolist()
+    answers = df["answer"].tolist()  # Storing answers in the global variable
 
-st.markdown('---')
-st.write('Creado por Eduardo Domínguez Navarrete')
-st.write('Alumno Consejero Ing. Informática')
+    # Create and train the vectorizer
+    vectorizer = TfidfVectorizer()
+    questions_vectorized = vectorizer.fit_transform(questions)
+
+    # Create and train the nearest neighbors model
+    model = NearestNeighbors(n_neighbors=1, metric="cosine")
+    model.fit(questions_vectorized)
+
+    print("Python: Model initialized successfully.")
+
+
+def get_answer(user_question):
+    """
+    Finds the most relevant answer for a given user question.
+    """
+    global vectorizer, model, answers
+
+    # Check if the model has been initialized
+    if model is None or vectorizer is None or answers is None:
+        return "The model is not ready yet. Please wait a moment."
+
+    # Vectorize the user's question
+    question_vectorized = vectorizer.transform([user_question])
+
+    # Find the nearest neighbor (the most similar question)
+    distances, indices = model.kneighbors(question_vectorized)
+
+    # If the similarity is too low, consider it a poor match
+    # The 0.7 threshold is an example, you can adjust it
+    if distances[0][0] > 0.7:
+        return "Disculpa, No tengo información sobre eso."
+
+    closest_index = indices[0][0]
+
+    return answers[closest_index]

--- a/src/components/chat-header/index.ts
+++ b/src/components/chat-header/index.ts
@@ -1,0 +1,131 @@
+import { BaseComponent } from "../core/base-component";
+import template from "./template.html?raw";
+import style from "./style.css?inline";
+import { chatbotService } from "@/services/chatbot-service";
+import type { AnsweringStrategy } from "@/services/answering-strategy";
+import { TransformersJsStrategy } from "@/services/strategies/transformers-strategy";
+import { PyodideStrategy } from "@/services/strategies/pyodide-strategy";
+
+const strategyMap: Record<string, () => AnsweringStrategy> = {
+  transformers: () => new TransformersJsStrategy(),
+  pyodide: () => new PyodideStrategy(),
+};
+
+class ChatHeader extends BaseComponent {
+  private $button: HTMLButtonElement | null = null;
+  private $dropdown: HTMLDivElement | null = null;
+  private $dropdownContent: HTMLDivElement | null = null;
+  private $buttonText: HTMLParagraphElement | null = null;
+
+  constructor() {
+    super();
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: "open" });
+    }
+  }
+
+  protected override connectedCallback(): void {
+    super.connectedCallback();
+  }
+
+  protected override get htmlTemplate(): string {
+    return template;
+  }
+
+  protected override get cssStyles(): string {
+    return style;
+  }
+
+  protected override setupEventListeners(): void {
+    if (this.shadowRoot === null) {
+      return;
+    }
+    this.$button = this.shadowRoot.querySelector("button");
+    this.$dropdown = this.shadowRoot.querySelector(".dropdown");
+    this.$dropdownContent = this.shadowRoot.querySelector(".dropdown-content");
+    this.$buttonText = this.shadowRoot.querySelector(".dropdown-btn p");
+
+    if (
+      !this.$button ||
+      !this.$dropdown ||
+      !this.$dropdownContent ||
+      !this.$buttonText
+    ) {
+      return;
+    }
+
+    // Listener for the button to ONLY toggle the dropdown
+    this.$button.addEventListener("click", () => {
+      this.$dropdownContent?.classList.toggle("show");
+      this.$dropdown?.blur();
+      this.$button?.blur();
+    });
+
+    this.$dropdown.addEventListener("click", async (e) => {
+      const target = e.target as HTMLElement;
+      const selectedLi = target.closest("li");
+      if (!this.$button || !this.$dropdownContent) {
+        return;
+      }
+      this.showCheckedState();
+
+      if (selectedLi?.tagName === "LI") {
+        const strategyKey = selectedLi.getAttribute("data-strategy");
+        const selectedText = selectedLi.querySelector("p")?.textContent;
+
+        if (this.$buttonText && selectedText) {
+          this.$buttonText.textContent = selectedText;
+        }
+
+        if (strategyKey && strategyMap[strategyKey]) {
+          // --- Start Loading State ---
+          this.$button?.blur();
+          this.$button.disabled = true;
+
+          this.setLoading(true);
+
+          this.$dropdownContent?.classList.remove("show");
+          const newStrategy = strategyMap[strategyKey]();
+          await chatbotService.setStrategy(newStrategy);
+
+          // --- End Loading State ---
+          this.setLoading(false);
+        }
+      }
+    });
+
+    document.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      if (target.tagName !== "CHAT-HEADER") {
+        this.$dropdownContent?.classList.remove("show");
+      }
+    });
+  }
+
+  private showCheckedState() {
+    const activeClass = this.shadowRoot?.querySelector("li.active");
+    activeClass?.classList.remove("active");
+    const $buttonText = this.$buttonText?.textContent;
+
+    const allLi = this.shadowRoot?.querySelectorAll("li");
+    allLi?.forEach((li) => {
+      const $p = li.querySelector("p");
+      if (!$p || !$buttonText) {
+        return;
+      }
+
+      if ($p.textContent === $buttonText) {
+        li.classList.add("active");
+      }
+    });
+  }
+
+  private setLoading(isLoading: boolean): void {
+    if (this.$button) {
+      this.$button.disabled = isLoading;
+      this.$button.classList.toggle("loading", isLoading);
+    }
+  }
+}
+
+customElements.define("chat-header", ChatHeader);

--- a/src/components/chat-header/style.css
+++ b/src/components/chat-header/style.css
@@ -1,0 +1,86 @@
+.dropdown {
+  position: relative;
+  display: inline-block;
+  margin-top: 0.5rem;
+  margin-left: 0.8rem;
+}
+
+.dropdown-btn {
+  display: flex;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.4rem;
+  padding-left: 0.7rem;
+  padding-right: 0.7rem;
+  font-size: 1.25rem;
+}
+
+.dropdown-btn:hover,
+.dropdown-btn:focus {
+  background-color: var(--color-background-light);
+  border-radius: 0.5rem;
+  outline: 3px solid var(--color-border-primary);
+}
+
+.dropdown-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  outline: none;
+  border-radius: 0.5rem;
+}
+
+.dropdown-btn p {
+  color: var(--color-text-primary);
+}
+
+.dropdown-btn svg {
+  stroke: var(--color-text-primary);
+  height: 1.2rem;
+  align-self: center;
+}
+
+li[data-strategy] svg {
+  display: none;
+  stroke: var(--color-text-primary);
+  height: 1.2rem;
+  align-self: center;
+}
+
+li[data-strategy].active svg {
+  display: block;
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: var(--color-border-primary);
+  min-width: 180px;
+  box-shadow: 0px 8px 16px 0px var(--color-shadow);
+  z-index: 1;
+  margin-top: 0.5rem;
+  padding: 0.3rem;
+  border-radius: 0.5rem;
+}
+
+.dropdown-content li {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.4rem;
+  padding-left: 0.7rem;
+  padding-right: 0.7rem;
+  font-size: 1rem;
+}
+
+.dropdown-content li:hover {
+  background-color: var(--color-background-light);
+  border-radius: 0.5rem;
+}
+
+.show {
+  display: block;
+}

--- a/src/components/chat-header/template.html
+++ b/src/components/chat-header/template.html
@@ -1,0 +1,56 @@
+<div class="dropdown" disable>
+  <button class="dropdown-btn">
+    <p>Transformer</p>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="lucide lucide-chevron-down-icon lucide-chevron-down"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  </button>
+  <ul id="dropdown" class="dropdown-content">
+    <li data-strategy="transformers">
+      <p>Transformer</p>
+
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="lucide lucide-check-icon lucide-check"
+      >
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    </li>
+    <li data-strategy="pyodide">
+      <p>Binary</p>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="lucide lucide-check-icon lucide-check"
+      >
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    </li>
+  </ul>
+</div>

--- a/src/components/chat-input/index.ts
+++ b/src/components/chat-input/index.ts
@@ -36,9 +36,8 @@ class ChatInput extends BaseComponent {
     // Start in a disabled state
     this.disableInput("Iniciando...");
 
-    document.addEventListener(
-      "assistant-response-finished",
-      () => this.enableInput,
+    document.addEventListener("assistant-response-finished", () =>
+      this.enableInput(),
     );
     document.addEventListener("app-ready", () => this.enableInput());
 
@@ -95,21 +94,18 @@ class ChatInput extends BaseComponent {
   }
 
   private enableInput() {
-    console.log("this", this);
     if (!this.$inputElement || !this.$sendButton) return;
-    if (window.visualViewport?.width ?? 0 > 700) {
-      this.$inputElement.focus();
-    }
-    console.log("Enabling input");
     this.$inputElement.disabled = false;
     this.$sendButton.disabled = false;
     this.$inputElement.value = "";
     this.$inputElement.placeholder = "Escribe tu pregunta";
+    if (window.visualViewport?.width ?? 0 > 700) {
+      this.$inputElement.focus();
+    }
   }
 
   private disableInput(placeholder = "Escribe tu pregunta") {
     if (!this.$inputElement || !this.$sendButton) return;
-    console.log("Disabling input");
     this.$inputElement.disabled = true;
     this.$inputElement.value = "";
     this.$sendButton.disabled = true;

--- a/src/components/chat-message/index.ts
+++ b/src/components/chat-message/index.ts
@@ -12,7 +12,7 @@ class ChatMessage extends BaseComponent {
 
   protected override connectedCallback(): void {
     super.connectedCallback();
-    const $li = this.querySelector("li");
+    // const $li = this.querySelector("li");
   }
 
   protected override get htmlTemplate(): string {

--- a/src/components/chat-messages/index.ts
+++ b/src/components/chat-messages/index.ts
@@ -54,8 +54,6 @@ class ChatMessages extends BaseComponent {
       }
       p?.classList.add("loading");
 
-      console.log("Message sent:", message);
-
       const answer = await this.chatbotService.findAnswer(message);
       await new Promise((resolve) => setTimeout(resolve, 1500));
       p.classList.remove("loading");
@@ -69,7 +67,6 @@ class ChatMessages extends BaseComponent {
       p.addEventListener(
         "animationend",
         () => {
-          console.log("Animation ended");
           thinkingMessageElement
             ?.querySelector("button")
             ?.classList.remove("hide");
@@ -137,7 +134,6 @@ class ChatMessages extends BaseComponent {
     const rootNode = this.shadowRoot.getRootNode() as ShadowRoot;
     const host = rootNode.host;
     host.scrollTop = host.scrollHeight; // Scroll to the bottom of the chat messages
-    console.log(host);
   }
 
   protected override disconnectedCallback(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,20 +4,23 @@ import "@/components/chat-container";
 import "@/components/side-bar";
 import "@/components/chat-input";
 import "@/components/chat-messages";
+import "@/components/chat-header";
+
 import { chatbotService } from "@/services/chatbot-service";
 import { env } from "@xenova/transformers";
 
-// // Tell the library to NOT look for models locally.
+// Tell the library to NOT look for models locally.
 env.allowLocalModels = false;
 env.useBrowserCache = false;
 
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
   <chat-container>
-    <side-bar></side-bar>
+    <!-- TODO: uncomment this later when we add the chat history feature-->
+    <!-- <side-bar></side-bar> -->
     <chat-window class="main-content">
-      <header-chat>
+      <chat-header>
         Header
-      </header-chat>
+      </chat-header>
         <chat-messages>
         </chat-messages>
       <chat-input></chat-input>

--- a/src/services/chatbot-service.ts
+++ b/src/services/chatbot-service.ts
@@ -1,4 +1,3 @@
-// src/services/chatbot.service.ts
 import type { AnsweringStrategy } from "./answering-strategy";
 import { TransformersJsStrategy } from "./strategies/transformers-strategy";
 
@@ -9,10 +8,13 @@ class ChatbotService {
     this.strategy = initialStrategy;
   }
 
-  public setStrategy(strategy: AnsweringStrategy) {
+  // Make this method async to await the initialization
+  public async setStrategy(strategy: AnsweringStrategy): Promise<void> {
     this.strategy = strategy;
-    // You might want to re-initialize when the strategy changes
-    // this.strategy.initialize();
+    console.log("Strategy changed to:", this.strategy.constructor.name);
+
+    // Await the initialization of the new strategy
+    await this.strategy.initialize();
   }
 
   public async initialize(): Promise<void> {

--- a/src/services/strategies/pyodide-strategy.ts
+++ b/src/services/strategies/pyodide-strategy.ts
@@ -1,27 +1,101 @@
-// src/services/strategies/pyodide.strategy.ts
 import type { AnsweringStrategy } from "../answering-strategy";
 
+// Make the global 'loadPyodide' function and our new flag available to TypeScript
+declare global {
+  interface Window {
+    pyodideScriptLoaded: boolean;
+  }
+}
+declare const loadPyodide: (config?: { indexURL: string }) => Promise<any>;
+
 export class PyodideStrategy implements AnsweringStrategy {
-  private pyodide: any = null; // To hold the Pyodide instance
+  private pyodide: any = null;
+  private isInitialized = false;
 
   async initialize(): Promise<void> {
-    console.log("Initializing Pyodide...");
-    // this.pyodide = await loadPyodide();
-    // await this.pyodide.loadPackage("numpy"); // etc.
-    // const pythonCode = await fetch('./main.py').then(res => res.text());
-    // this.pyodide.runPython(pythonCode);
-    console.log("Pyodide ready.");
+    console.log("Initializing Pyodide strategy...");
+
+    // If we've already set up this strategy, don't do it again.
+    if (this.isInitialized) {
+      console.log("Pyodide strategy already initialized.");
+      return;
+    }
+    // 1. Dynamically load the main Pyodide script from the CDN
+    await this.loadScript(
+      "https://cdn.jsdelivr.net/pyodide/v0.28.0/full/pyodide.js",
+    );
+
+    // 2. Initialize the Pyodide environment
+    this.pyodide = await loadPyodide({
+      indexURL: "https://cdn.jsdelivr.net/pyodide/v0.28.0/full/",
+    });
+
+    console.log("Pyodide loaded. Installing packages...");
+
+    // 3. Load micropip to install Python packages
+    await this.pyodide.loadPackage("micropip");
+    const micropip = this.pyodide.pyimport("micropip");
+
+    // 4. Install the required libraries (pandas and scikit-learn)
+    await micropip.install(["pandas", "scikit-learn"]);
+    console.log("Python packages installed.");
+
+    // 5. Load our Python script and dataset concurrently
+    const [pythonCode, jsonData] = await Promise.all([
+      fetch("/main.py").then((res) => res.text()),
+      fetch("/dataset.json").then((res) => res.json()),
+    ]);
+
+    // 6. Run the Python script to define the functions
+    this.pyodide.runPython(pythonCode);
+
+    // 7. Call the initialization function in Python, passing it the dataset
+    const initializeModelPy = this.pyodide.globals.get("initialize_model");
+    initializeModelPy(JSON.stringify(jsonData));
+    initializeModelPy.destroy(); // Free up memory
+
+    // Mark this instance as initialized
+    this.isInitialized = true;
+    console.log("Pyodide strategy is ready.");
   }
 
   async getAnswer(question: string): Promise<string> {
     if (!this.pyodide) {
-      throw new Error("Strategy not initialized. Call initialize() first.");
+      throw new Error("Pyodide strategy has not been initialized.");
     }
-    // const get_answer = this.pyodide.globals.get('get_answer_from_python');
-    // const answer = get_answer(question);
-    // return answer;
 
-    // Placeholder logic for now:
-    return `Pyodide would process the question: "${question}"`;
+    // Get a reference to the Python function
+    const getAnswerPy = this.pyodide.globals.get("get_answer");
+
+    // Call the Python function with the user's question
+    const answer = getAnswerPy(question);
+
+    // Free up the memory used by the function proxy
+    getAnswerPy.destroy();
+
+    return answer;
+  }
+
+  /**
+   * Helper to dynamically load a script.
+   */
+  private loadScript(src: string): Promise<void> {
+    // 1. Check our global flag first.
+    if (window.pyodideScriptLoaded) {
+      console.log("Pyodide script already loaded.");
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = src;
+      script.onload = () => {
+        // 2. Set the flag to true once the script loads successfully.
+        window.pyodideScriptLoaded = true;
+        resolve();
+      };
+      script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
+      document.head.appendChild(script);
+    });
   }
 }

--- a/src/services/strategies/transformers-strategy.ts
+++ b/src/services/strategies/transformers-strategy.ts
@@ -1,5 +1,4 @@
 import { pipeline, cos_sim } from "@xenova/transformers";
-
 import type { AnsweringStrategy } from "../answering-strategy";
 
 // You can move your knowledge base here or import it from another file
@@ -59,13 +58,15 @@ export class TransformersJsStrategy implements AnsweringStrategy {
       }
     }
 
-    if (best_match.score < 0.5) {
-      return "I'm sorry, I don't have information about that.";
+    if (best_match.score < 0.7) {
+      return "Disculpa, No tengo información sobre eso.";
+      // return "I'm sorry, I don't have information about that.";
     }
 
     const answer = this.knowledge_base[best_match?.index]?.answer;
     if (!answer) {
-      return "I'm sorry, I don't have an answer for that.";
+      return "Disculpa, No tengo información sobre eso.";
+      // return "I'm sorry, I don't have an answer for that.";
     }
 
     return answer;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,7 @@
   --color-text-muted: #6b7280;
   --color-text-primary: #e6edf3;
   --color-text-secondary: #9c9d9d;
+  --color-shadow: rgba(30, 41, 59, 0.3);
   scroll-behavior: smooth;
 }
 
@@ -28,7 +29,9 @@ chat-container {
   max-height: 100dvh;
   height: 100dvh;
   display: grid;
-  grid-template-columns: minmax(15rem, 1fr) 5fr;
+  /* TODO: uncomment this later when we add the chat history feature */
+  /* grid-template-columns: minmax(15rem, 1fr) 5fr; */
+  grid-template-columns: 1fr;
 }
 
 side-bar {


### PR DESCRIPTION
Introduces a new answering strategy using Pyodide and improves the overall chat user experience.

- Implemented a `PyodideStrategy` to run a scikit-learn model in the browser.
- The `<chat-header>` now allows switching between AI models at runtime.
- Fixed a bug where the chat input would not re-enable after the assistant's response.
- Improved UX by automatically focusing the chat input on desktop devices.